### PR TITLE
fix: files should now generate properly on ng add

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Cutting a release
+
+- `yarn build`
+- `cd dist && angular-redux`
+- `npm publish`

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build angular-redux && tsc -p projects/angular-redux/tsconfig.schematics.json && yarn build:copy",
-    "build:copy": "cd ./projects/angular-redux/schematics && copyfiles \"**/*.json\" ../../../dist/angular-redux/schematics",
+    "build:copy": "cd ./projects/angular-redux/schematics && copyfiles \"**/*.json\" ../../../dist/angular-redux/schematics && copyfiles \"**/*.template\" ../../../dist/angular-redux/schematics",
     "build:ng": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "yarn test:ng && yarn test:schematics",


### PR DESCRIPTION
There was previously a bug that prevented the `store` files from generating when `ng add` was ran. This should fix that