### PR TITLE
Fix lifecycle method usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,6 @@ After you have submitted your pull request, we'll try to get back to you as soon
 
 Thank you for contributing!
 
-
 # Cutting a release
 
 If you are a maintainer and want to cut a release, follow these steps:

--- a/angular.json
+++ b/angular.json
@@ -139,9 +139,7 @@
             "outputPath": "dist/angular-redux-injector-demo",
             "index": "projects/angular-redux-injector-demo/src/index.html",
             "browser": "projects/angular-redux-injector-demo/src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "projects/angular-redux-injector-demo/tsconfig.app.json",
             "assets": [
               {
@@ -149,9 +147,7 @@
                 "input": "projects/angular-redux-injector-demo/public"
               }
             ],
-            "styles": [
-              "projects/angular-redux-injector-demo/src/styles.css"
-            ],
+            "styles": ["projects/angular-redux-injector-demo/src/styles.css"],
             "scripts": []
           },
           "configurations": {

--- a/projects/angular-redux-injector-demo/src/app/utils/async-run-in-injection-context.ts
+++ b/projects/angular-redux-injector-demo/src/app/utils/async-run-in-injection-context.ts
@@ -17,8 +17,6 @@ export const asyncRunInInjectionContext = <TReturn>(
   });
 };
 
-export type RunInInjectionContextProps<
-  T extends object,
-> = T & {
+export type RunInInjectionContextProps<T extends object> = T & {
   injector: EnvironmentInjector;
 };

--- a/projects/angular-redux-injector-demo/src/index.html
+++ b/projects/angular-redux-injector-demo/src/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>AngularReduxInjectorDemo</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>AngularReduxInjectorDemo</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/projects/angular-redux-injector-demo/src/main.ts
+++ b/projects/angular-redux-injector-demo/src/main.ts
@@ -2,5 +2,6 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err),
+);

--- a/projects/angular-redux-injector-demo/tsconfig.app.json
+++ b/projects/angular-redux-injector-demo/tsconfig.app.json
@@ -6,10 +6,6 @@
     "outDir": "../../out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
 }


### PR DESCRIPTION
As pointed out by @MShake on StackOverflow:

https://stackoverflow.com/questions/79070506/enable-to-retrieve-data-initialize-by-a-dispatched-action-when-the-component-is

Any actions dispatched by `OnInit` were not being tracked by `injectSelector` due to the timing of `effect`.

This PR fixes this issue by removing `effect` to do cleanup in favor of `DestroyRef`